### PR TITLE
Preset selection feature

### DIFF
--- a/JS-Sandpile.html
+++ b/JS-Sandpile.html
@@ -236,21 +236,18 @@
 			</ul>
 		</div>
 		<!-- ############################################################ Mouse Controls -->
-		<div style="display: none">
 		<div id="mouse controls" class="controlGroup">
 			<p class="groupTitle">Mouse controls</p>
-			<select id="mouseOperation">
-			  <option value="addOne">Add</option>
-			  <option value="rmOne">Remove</option>
-			  <option value="setOne">Set</option>
-			  <option value="select">Select</option>
+			<select id="mouseOperation" style="margin-top: 8px;height: 32px;display: table;width: -webkit-fill-available;">
+			  <option value="placeOne">Place Piece</option>
+			  <option value="rmOne">Remove Piece</option>
 			</select>
-			<div id="maskMouseRepeat" style="display:inline;">
-			&nbsp;&nbsp;times&nbsp;&nbsp;
-			<input type="number" id="mouseOperationRepeat" value="1" min="0" max="999999"style="width: 70px;" />
-			</div>
 			<br><br>
-			<div style="display:flex;">
+			<div id="maskMouseRepeat" style="display:none;">
+				&nbsp;&nbsp;times&nbsp;&nbsp;
+				<input type="number" id="mouseOperationRepeat" value="1" min="0" max="999999"style="width: 70px;" />
+				</div>
+			<div style="display:none;">
 			  Mouse radius :
 			  <input type="range" min="1" max="8" value="1" step="1" id="brushRange" style="width:150px;margin-left:10px;" list="steplist">
 			  <datalist id="steplist">
@@ -266,6 +263,7 @@
 			</div>
 		</div> <!-- Mouse controls -->
 
+		<div style="display: none">
 		<!-- ############################################################ Operations / Secondary Controls -->
 		<div id="secondary controls" class="controlGroup">
 			<p class="groupTitle">Sandpile operations</p>

--- a/JS-Sandpile.html
+++ b/JS-Sandpile.html
@@ -216,31 +216,23 @@
 		</div> <!-- Main controls  -->
 
 		<!-- ############################################################ Puzzle Piece Creation-->
-		<div id="preset controls" class="controlGroup">
+		<div id="puzzle piece preset creation controls" class="controlGroup">
 			<p class="groupTitle">Create Puzzle Pieces</p>
 			<div id="maskMouseRepeat" style="display:inline;">
 			&nbsp;&nbsp;Width&nbsp;&nbsp;
-			<input type="number" id="pieceWidth" value="1" min="0" max="999999"style="width: 55px;" />
+			<input type="number" id="pieceWidth" value="2" min="1" max="999999"style="width: 55px;" />
 			</div>
 			<div id="maskMouseRepeat" style="display:inline;">
 				&nbsp;&nbsp;Height&nbsp;&nbsp;
-				<input type="number" id="pieceHeight" value="1" min="0" max="999999"style="width: 55px;" />
+				<input type="number" id="pieceHeight" value="1" min="1" max="999999"style="width: 55px;" />
 			</div>
 			<br>
 			<button id="puzzlePieceCreate" onclick="puzzlePieceCreate()" class="btn btn-default" style="margin-top:10px;display: table;width: -webkit-fill-available;">Add</button>
 		</div> 
 		<!-- ############################################################ Puzzle Pieces-->
-		<div id="presets controls" class="controlGroup">
+		<div id="puzzle piece preset selection controls" class="controlGroup" display="grid">
 			<p class="groupTitle">Presets</p>
-			<ul id="presetList" style="margin-left: 0; padding-left: 0">
-				<li>
-					<input type="radio" onclick="presetSelect()" style="display: none" name="preset" id="placeholderPreset1" />
-					<label id="presetSelectID" for="placeholderPreset1" class="btn btn-default" style="margin-top:10px;display: table;width: -webkit-fill-available;">Width x Height</button>
-				</li>
-				<li>
-					<input type="radio" onclick="presetSelect()" style="display: none" name="preset" id="placeholderPreset2"/>
-					<label id="presetSelectID" for="placeholderPreset2" class="btn btn-default" style="margin-top:10px;display: table;width: -webkit-fill-available;">Width x Height</button>
-				</li>
+			<ul id="presetList" style="margin-left: 0; padding-left: 0" display="grid">
 			</ul>
 		</div>
 		<!-- ############################################################ Mouse Controls -->

--- a/JS-Sandpile.html
+++ b/JS-Sandpile.html
@@ -236,6 +236,7 @@
 			</ul>
 		</div>
 		<!-- ############################################################ Mouse Controls -->
+		<div style="display: none">
 		<div id="mouse controls" class="controlGroup">
 			<p class="groupTitle">Mouse controls</p>
 			<select id="mouseOperation">
@@ -440,7 +441,7 @@
               <button id="batch_identities_diff" onclick="batch_identities_diff()" style="margin-top:5px;font-family: monospace;" class="btn btn-default">batch_identities_diff()</button>
             </div>
         </div>
-
+		</div>
 		<!-- ############################################################ Credits -->
 		<div class="credits">
           <img src="./css/cc-heart.png" style="height:16px">

--- a/css/elements.css
+++ b/css/elements.css
@@ -124,6 +124,12 @@ input:checked + .slider:before {
   transform: translateX(13px);
 }
 
+li input:checked + label{
+  box-shadow: inset 1px 2px 5px #777;
+  transform: translateY(1px);
+  background: #e5e5e5;
+}
+
 /* Rounded sliders */
 .slider.round {
   border-radius: 17px;

--- a/js/Tiling.js
+++ b/js/Tiling.js
@@ -149,8 +149,8 @@ class Tiling{
 	// ------------------------------------------------
 	constructor(tiles, hide=false, recenter=false){
 		// Temporarily hardcoding these values
-		this.numRows = document.getElementById("cW").value;;
-		this.numCols = document.getElementById("cH").value;;
+		this.numRows = document.getElementById("cH").value;;
+		this.numCols = document.getElementById("cW").value;;
 
 		this.tiles = tiles;
 		this.puzzlePieces = [];
@@ -574,7 +574,7 @@ class Tiling{
 			const cur_col = Math.floor(tileid / this.numRows); 
                     
 			// to check if the puzzlepiece doesn't break and some part goes to the next row
-			if(cur_col+piece.width >this.numRows|| cur_row +piece.height >this.numCols){
+			if(cur_col+piece.width >this.numCols|| cur_row +piece.height >this.numRows){
 				return false
 			}
 			for(var i =0;i<piece.height;i++){
@@ -605,11 +605,12 @@ class Tiling{
 			if (!color)
 				var color = new THREE.Color(Math.random(), Math.random(), Math.random());
 				piece.color = color
-			for (var i=0; i<piece.height; i++){
-				for (var j=0; j<piece.width; j++){
-					const tile = this.tiles[tileid + i + this.numCols * j]
+			for (var i=0; i<piece.width; i++){
+				for (var j=0; j<piece.height; j++){
+					const tile = this.tiles[tileid + i*this.numRows +  j]
 					tile.puzzlePieceId = piece.id;
-					tile.puzzlePieceBlockId = blocks[i * piece.width + j].id;
+					console.log(i*piece.width + j)
+					tile.puzzlePieceBlockId = blocks[i * piece.height + j].id;
 //					var color = new THREE.Color( 90/255, 156/255, 122/255 );
 					this.colorTile(tile.id, color)
 				}
@@ -626,9 +627,9 @@ class Tiling{
 			var pieceToBeRemoved = this.puzzlePieces.find((piece)=> piece.id === toBeRemovedId);
 			var originTile = pieceToBeRemoved.location;
 			var color = new THREE.Color(1, 1, 1);
-			for (var i=0; i<pieceToBeRemoved.height; i++){
-				for (var j=0; j<pieceToBeRemoved.width; j++){
-					const tile = this.tiles[originTile + i + this.numCols * j]
+			for (var i=0; i<pieceToBeRemoved.width; i++){
+				for (var j=0; j<pieceToBeRemoved.height; j++){
+					const tile = this.tiles[originTile + i*this.numRows + j]
 					tile.puzzlePieceId = -1;
 					tile.puzzlePieceBlockId = -1;
 //					var color = new THREE.Color( 90/255, 156/255, 122/255 );

--- a/js/Tiling.js
+++ b/js/Tiling.js
@@ -616,7 +616,25 @@ class Tiling{
 			} 
 			this.puzzlePieces.push(piece)
 			// Loop over blocks and place them relative to the tileid's coordinates.
-		}
+		}  
+
+		removePuzzlePiece(tileid)
+		{	
+			var toBeRemovedId = this.tiles[tileid].puzzlePieceId
+			var pieceToBeRemoved = this.puzzlePieces.find((piece)=> piece.id === toBeRemovedId);
+			var originTile = pieceToBeRemoved.location;
+			var color = new THREE.Color(1, 1, 1);
+			for (var i=0; i<pieceToBeRemoved.height; i++){
+				for (var j=0; j<pieceToBeRemoved.width; j++){
+					const tile = this.tiles[originTile + i + this.numCols * j]
+					tile.puzzlePieceId = -1;
+					tile.puzzlePieceBlockId = -1;
+//					var color = new THREE.Color( 90/255, 156/255, 122/255 );
+					this.colorTile(tile.id, color)
+				}
+			} 
+			//either delete the piece or store it in a separate array
+		}  
 	
 		addSelectedPuzzlePiece(tileid, color)
 		{

--- a/js/Tiling.js
+++ b/js/Tiling.js
@@ -149,8 +149,8 @@ class Tiling{
 	// ------------------------------------------------
 	constructor(tiles, hide=false, recenter=false){
 		// Temporarily hardcoding these values
-		this.numRows = 10;
-		this.numCols = 10;
+		this.numRows = document.getElementById("cW").value;;
+		this.numCols = document.getElementById("cH").value;;
 
 		this.tiles = tiles;
 		this.puzzlePieces = [];
@@ -569,12 +569,12 @@ class Tiling{
 
 		checkPuzzlePiecePlaceable(piece, tileid)
 		{
-			const cur_row = tileid % this.numRows;
+			const cur_col = tileid % this.numRows-1;
 			
-			const cur_col = Math.floor(tileid / this.numRows); 
+			const cur_row = Math.floor(tileid / this.numRows)-1; 
                     
 			// to check if the puzzlepiece doesn't break and some part goes to the next row
-			if(cur_row+piece.height >this.numRows|| cur_col +piece.width >this.numCols){
+			if(cur_row+piece.width >this.numRows|| cur_col +piece.height >this.numCols){
 				return false
 			}
 			for(var i =0;i<piece.height;i++){

--- a/js/Tiling.js
+++ b/js/Tiling.js
@@ -577,9 +577,9 @@ class Tiling{
 			if(cur_col+piece.width >this.numCols|| cur_row +piece.height >this.numRows){
 				return false
 			}
-			for(var i =0;i<piece.height;i++){
-				for(var j =0;j<piece.width;j++){
-					const index = tileid + i + this.numCols * j;
+			for(var i =0;i<piece.width;i++){
+				for(var j =0;j<piece.height;j++){
+					const index = tileid + i*this.numRows +  j;
 					// to check index validity
 					if(index >= this.tiles.length || index<0){
 						return false;
@@ -609,7 +609,6 @@ class Tiling{
 				for (var j=0; j<piece.height; j++){
 					const tile = this.tiles[tileid + i*this.numRows +  j]
 					tile.puzzlePieceId = piece.id;
-					console.log(i*piece.width + j)
 					tile.puzzlePieceBlockId = blocks[i * piece.height + j].id;
 //					var color = new THREE.Color( 90/255, 156/255, 122/255 );
 					this.colorTile(tile.id, color)

--- a/js/Tiling.js
+++ b/js/Tiling.js
@@ -617,4 +617,24 @@ class Tiling{
 			this.puzzlePieces.push(piece)
 			// Loop over blocks and place them relative to the tileid's coordinates.
 		}
+	
+		addSelectedPuzzlePiece(tileid, color)
+		{
+			// dimensions of the puzzlePiece to create
+			const val = document.querySelector('input[name="preset"]:checked');
+			if (!val)
+				throw Error("No puzzle piece selected")
+			const dims = val.value.split(',');
+			const pW = Number(dims[0]);
+			const pH = Number(dims[1]);
+			var nextPuzzlePieceId = 0;
+			if (currentTiling.puzzlePieces.length > 0)
+				nextPuzzlePieceId = currentTiling.puzzlePieces.at(-1).id + 1
+			// create a new PuzzlePiece
+			const piece = new PuzzlePiece(nextPuzzlePieceId, pW, pH)
+
+			// place chosen PuzzlePiece at the selected tile.
+			console.log(`Attempting to place piece id ${nextPuzzlePieceId} on tile id ${tileid}`)
+			currentTiling.placePuzzlePiece(piece, tileid)
+		}
 }

--- a/js/Tiling.js
+++ b/js/Tiling.js
@@ -569,12 +569,12 @@ class Tiling{
 
 		checkPuzzlePiecePlaceable(piece, tileid)
 		{
-			const cur_col = tileid % this.numRows-1;
+			const cur_row = tileid % this.numRows;
 			
-			const cur_row = Math.floor(tileid / this.numRows)-1; 
+			const cur_col = Math.floor(tileid / this.numRows); 
                     
 			// to check if the puzzlepiece doesn't break and some part goes to the next row
-			if(cur_row+piece.width >this.numRows|| cur_col +piece.height >this.numCols){
+			if(cur_col+piece.width >this.numRows|| cur_row +piece.height >this.numCols){
 				return false
 			}
 			for(var i =0;i<piece.height;i++){
@@ -621,6 +621,8 @@ class Tiling{
 		removePuzzlePiece(tileid)
 		{	
 			var toBeRemovedId = this.tiles[tileid].puzzlePieceId
+			if (toBeRemovedId===-1)
+				throw Error("No puzzle piece at location")
 			var pieceToBeRemoved = this.puzzlePieces.find((piece)=> piece.id === toBeRemovedId);
 			var originTile = pieceToBeRemoved.location;
 			var color = new THREE.Color(1, 1, 1);

--- a/js/app.js
+++ b/js/app.js
@@ -708,22 +708,8 @@ function CanvasClick(event, force){
 				default:
 					// What does this do?
 					currentTiling.lastChange = 0;
-         const val = document.querySelector('input[name="preset"]:checked');
-          if (!val)
-             throw Error("No puzzle piece selected")
-         const dims = val.value.split(',');
-         const pW = Number(dims[0]);
-         const pH = Number(dims[1]);
-					if (currentTiling.puzzlePieces.length > 0)
-						nextPuzzlePieceId = currentTiling.puzzlePieces.at(-1).id + 1
-					else
-						nextPuzzlePieceId = 0;
-					// create a new PuzzlePiece
-					piece = new PuzzlePiece(nextPuzzlePieceId, pW, pH)
-
-					// place chosen PuzzlePiece at the selected tile.
-					console.log(`Attempting to place piece id ${nextPuzzlePieceId} on tile id ${lastTile}`)
-					currentTiling.placePuzzlePiece(piece, lastTile)
+					console.log("Adding puzzle piece " + selectedPreset + " to tile id " + lastTile)
+					currentTiling.addSelectedPuzzlePiece(lastTile);
 					break;
 			}
 

--- a/js/app.js
+++ b/js/app.js
@@ -681,18 +681,14 @@ function CanvasClick(event, force){
 			switch(mouseTODO){
 				case "rmOne":
 					currentTiling.lastChange = 0;
-					var brush_t = zone(lastTile, document.getElementById("brushRange").value)
-					for(var k=0; k<brush_t.length; k++){
-						currentTiling.remove(brush_t[k], nbTimes);
-					}
+					console.log("Removing puzzle piece from tile id " + lastTile)
+					currentTiling.removePuzzlePiece(lastTile);
 					break;
 				
-				case "setOne":
+				case "placeOne":
 					currentTiling.lastChange = 0;
-					var brush_t = zone(lastTile, document.getElementById("brushRange").value)
-					for(var k=0; k<brush_t.length; k++){
-						currentTiling.set(brush_t[k], nbTimes);
-					}
+					console.log("Adding puzzle piece " + selectedPreset + " to tile id " + lastTile)
+					currentTiling.addSelectedPuzzlePiece(lastTile);
 					break;
 
 				case "select":
@@ -764,7 +760,7 @@ function puzzlePieceCreate(){
 					 </label>`
 	presetList.appendChild(li);
 	li.children[0].checked=true;
-	selectedPreset = presets.length;
+	selectedPreset = presets.length;//this is not right, if we are accessing the information about the preset from the html directly do we even need this?
 } 
 
 function presetSelect(val) {

--- a/js/app.js
+++ b/js/app.js
@@ -681,7 +681,12 @@ function CanvasClick(event, force){
 			switch(mouseTODO){
 				case "rmOne":
 					currentTiling.lastChange = 0;
-					console.log("Removing puzzle piece from tile id " + lastTile)
+					//var brush_t = zone(lastTile, document.getElementById("brushRange").value)
+					//for(var k=0; k<brush_t.length; k++){
+					//	currentTiling.removePuzzlePiece(brush_t[k]);
+					//}
+
+					console.log("Removing puzzle piece from tile id " + lastTile);
 					currentTiling.removePuzzlePiece(lastTile);
 					break;
 				

--- a/js/app.js
+++ b/js/app.js
@@ -766,24 +766,29 @@ function puzzlePieceCreate(){
 	var presetList = document.getElementById("presetList");
 	var width = Number(document.getElementById("pieceWidth").value);
 	var height = Number(document.getElementById("pieceHeight").value);
+	if (width <= 0 || height <= 0)
+			throw Error("Puzzle piece dimensions cannot be non-positive.")
 	presets.push({width, height});
-	const li = document.createElement("LI");
-	// removing oninput="presetSelect(this)" temporary
-	const st = `<li>
-			<input type="radio"  style="display: none" name="preset" id="`+presets.length+`"  value="`+presets.length+`"/>
-			<label id="presetSelectID" for="`+presets.length+`" class="btn btn-default" style="margin-top:10px;display: table;width: -webkit-fill-available;" value="`+presets.length+`">`+width+` x `+height+`</button>
-				</li>`
-	li.innerHTML= st
-	li.addEventListener('click', presetSelect)
+	const li = document.createElement("li");
+	li.innerHTML = `<input type="radio" oninput="presetSelect(this)" style="display: none" name="preset" id="presetselector`+presets.length+`" value="`+width+`,`+height+`"/>
+					<label for="presetselector`+presets.length+`" class="preset btn btn-default" style="width: -webkit-fill-available;" value="`+presets.length+`">`
+					 + width + ` ⨉ ` + height +`
+					 </label>`
 	presetList.appendChild(li);
+	li.children[0].checked=true;
+	selectedPreset = presets.length;
 } 
-function presetSelect(event) {
-    console.log(event);
+
+function presetSelect(val) {
+	// nothing to do here
+	return;
+//	console.log(document.querySelector('input[name="preset"]:checked').value);
+//	val.checked = true;
+//	console.log(val.value.split(','));
+//	var presetList = document.getElementById("presetList");
+//	selectedPreset = val.value;
 }
-/*function presetSelect(val){
-	console.log(val.target.htmlFor);
-	var selectedPreset = val.target.htmlFor-1;
-}*/
+
 var holdMouse = false;
 var lastTile = 0;
 var previousTile = -1;

--- a/js/app.js
+++ b/js/app.js
@@ -708,10 +708,12 @@ function CanvasClick(event, force){
 				default:
 					// What does this do?
 					currentTiling.lastChange = 0;
-
-					// dimensions of the puzzlePiece to create
-					pW = 2 //presets[selectedPreset][0]
-					pH = 3 // presets[selectedPreset][1];
+         const val = document.querySelector('input[name="preset"]:checked');
+          if (!val)
+             throw Error("No puzzle piece selected")
+         const dims = val.value.split(',');
+         const pW = Number(dims[0]);
+         const pH = Number(dims[1]);
 					if (currentTiling.puzzlePieces.length > 0)
 						nextPuzzlePieceId = currentTiling.puzzlePieces.at(-1).id + 1
 					else


### PR DESCRIPTION
- Add some CSS to imitate the look of a button staying pressed.
- Don't need any `onclick` events because that's handled by the browser's own radio button logic (only one can be selected, etc.)
- The value of the radio buttons is `width,height`. This probably should not be how it is, because it won't generalise to different shapes. This was just an experiment.
- Changed the minimum and maximum dimensions to 1 instead of 0, and a check in case negative values are passed anyway.

<img width="270" alt="Screenshot 2024-06-08 at 04 46 48" src="https://github.com/RectangularTilings/TilingMachine/assets/122440845/4b5cb20e-b361-4f52-8a5e-d2d48a359422">